### PR TITLE
Fix/python311 mutable default

### DIFF
--- a/ptgaze/common/face_model_68.py
+++ b/ptgaze/common/face_model_68.py
@@ -24,7 +24,7 @@ class FaceModel68(FaceModel):
     The model coordinate system is defined as the camera coordinate
     system rotated 180 degrees around the Y axis.
     """
-    LANDMARKS: np.ndarray = field(default_factory=lambda: np.array([
+    LANDMARKS: np.ndarray = dataclasses.field(default_factory=lambda: np.array([
         [-0.07141807, -0.02827123, 0.08114384],
         [-0.07067417, -0.00961522, 0.08035654],
         [-0.06844646, 0.00895837, 0.08046731],
@@ -96,10 +96,10 @@ class FaceModel68(FaceModel):
     ],
                                      dtype=np.float64))
 
-    REYE_INDICES: np.ndarray = field(default_factory=lambda: np.array([36, 39]))
-    LEYE_INDICES: np.ndarray = field(default_factory=lambda: np.array([42, 45]))
-    MOUTH_INDICES: np.ndarray = field(default_factory=lambda: np.array([48, 54]))
-    NOSE_INDICES: np.ndarray = field(default_factory=lambda: np.array([31, 35]))
+    REYE_INDICES: np.ndarray = dataclasses.field(default_factory=lambda: np.array([36, 39]))
+    LEYE_INDICES: np.ndarray = dataclasses.field(default_factory=lambda: np.array([42, 45]))
+    MOUTH_INDICES: np.ndarray = dataclasses.field(default_factory=lambda: np.array([48, 54]))
+    NOSE_INDICES: np.ndarray = dataclasses.field(default_factory=lambda: np.array([31, 35]))
 
     CHIN_INDEX: int = 8
     NOSE_INDEX: int = 30

--- a/ptgaze/common/face_model_68.py
+++ b/ptgaze/common/face_model_68.py
@@ -24,7 +24,7 @@ class FaceModel68(FaceModel):
     The model coordinate system is defined as the camera coordinate
     system rotated 180 degrees around the Y axis.
     """
-    LANDMARKS: np.ndarray = np.array([
+    LANDMARKS: np.ndarray = field(default_factory=lambda: np.array([
         [-0.07141807, -0.02827123, 0.08114384],
         [-0.07067417, -0.00961522, 0.08035654],
         [-0.06844646, 0.00895837, 0.08046731],
@@ -94,12 +94,12 @@ class FaceModel68(FaceModel):
         [0., 0.03791103, 0.0180805],
         [-0.00771924, 0.03711846, 0.01940396],
     ],
-                                     dtype=np.float64)
+                                     dtype=np.float64))
 
-    REYE_INDICES: np.ndarray = np.array([36, 39])
-    LEYE_INDICES: np.ndarray = np.array([42, 45])
-    MOUTH_INDICES: np.ndarray = np.array([48, 54])
-    NOSE_INDICES: np.ndarray = np.array([31, 35])
+    REYE_INDICES: np.ndarray = field(default_factory=lambda: np.array([36, 39]))
+    LEYE_INDICES: np.ndarray = field(default_factory=lambda: np.array([42, 45]))
+    MOUTH_INDICES: np.ndarray = field(default_factory=lambda: np.array([48, 54]))
+    NOSE_INDICES: np.ndarray = field(default_factory=lambda: np.array([31, 35]))
 
     CHIN_INDEX: int = 8
     NOSE_INDEX: int = 30

--- a/ptgaze/common/face_model_mediapipe.py
+++ b/ptgaze/common/face_model_mediapipe.py
@@ -24,7 +24,7 @@ class FaceModelMediaPipe(FaceModel):
     The model coordinate system is defined as the camera coordinate
     system rotated 180 degrees around the Y axis.
     """
-    LANDMARKS: np.ndarray = field(default_factory=lambda: np.array([
+    LANDMARKS: np.ndarray = dataclasses.field(default_factory=lambda: np.array([
         [0.0, 0.02279539, 0.01496097],
         [0.0, 0.0, 0.0],
         [0.0, 0.00962159, 0.01417337],
@@ -496,10 +496,10 @@ class FaceModelMediaPipe(FaceModel):
     ],
                                      dtype=np.float64))
 
-    REYE_INDICES: np.ndarray = field(default_factory=lambda: np.array([33, 133]))
-    LEYE_INDICES: np.ndarray = field(default_factory=lambda: np.array([362, 263]))
-    MOUTH_INDICES: np.ndarray = field(default_factory=lambda: np.array([78, 308]))
-    NOSE_INDICES: np.ndarray = field(default_factory=lambda: np.array([240, 460]))
+    REYE_INDICES: np.ndarray = dataclasses.field(default_factory=lambda: np.array([33, 133]))
+    LEYE_INDICES: np.ndarray = dataclasses.field(default_factory=lambda: np.array([362, 263]))
+    MOUTH_INDICES: np.ndarray = dataclasses.field(default_factory=lambda: np.array([78, 308]))
+    NOSE_INDICES: np.ndarray = dataclasses.field(default_factory=lambda: np.array([240, 460]))
 
     CHIN_INDEX: int = 199
     NOSE_INDEX: int = 1

--- a/ptgaze/common/face_model_mediapipe.py
+++ b/ptgaze/common/face_model_mediapipe.py
@@ -24,7 +24,7 @@ class FaceModelMediaPipe(FaceModel):
     The model coordinate system is defined as the camera coordinate
     system rotated 180 degrees around the Y axis.
     """
-    LANDMARKS: np.ndarray = np.array([
+    LANDMARKS: np.ndarray = field(default_factory=lambda: np.array([
         [0.0, 0.02279539, 0.01496097],
         [0.0, 0.0, 0.0],
         [0.0, 0.00962159, 0.01417337],
@@ -494,12 +494,12 @@ class FaceModelMediaPipe(FaceModel):
         [0.04253081, -0.03899161, 0.04160299],
         [0.0453, -0.04036865, 0.04135919],
     ],
-                                     dtype=np.float64)
+                                     dtype=np.float64))
 
-    REYE_INDICES: np.ndarray = np.array([33, 133])
-    LEYE_INDICES: np.ndarray = np.array([362, 263])
-    MOUTH_INDICES: np.ndarray = np.array([78, 308])
-    NOSE_INDICES: np.ndarray = np.array([240, 460])
+    REYE_INDICES: np.ndarray = field(default_factory=lambda: np.array([33, 133]))
+    LEYE_INDICES: np.ndarray = field(default_factory=lambda: np.array([362, 263]))
+    MOUTH_INDICES: np.ndarray = field(default_factory=lambda: np.array([78, 308]))
+    NOSE_INDICES: np.ndarray = field(default_factory=lambda: np.array([240, 460]))
 
     CHIN_INDEX: int = 199
     NOSE_INDEX: int = 1


### PR DESCRIPTION
### Summary
This PR fixes the bug where mutable default happend when installing ptgaze in python3.11 environment.

### Changes
Fixed mutable default in `@dataclasses(frozen=True)` class to `dataclasses.field(default_factory=...)` style.

### Root Cause
Due to the Update in the [dataclasses](https://docs.python.org/3/library/dataclasses.html) library in python3.11 environment  (source is [here](https://docs.python.org/3.11/library/dataclasses.html#mutable-default-values)).